### PR TITLE
notes about payload size when used in the browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,27 @@ streamx aims to be compatible with Node.js streams whenever it is reasonable to 
 This means that streamx streams behave a lot like Node.js streams from the outside but still provides the
 improvements above.
 
+#### Smaller browser footprint
+
+streamx has a much smaller footprint when compiled for the browser:
+
+```
+$ for x in stream{,x}; do echo $x: $(browserify -r $x | wc -c) bytes; done
+stream: 173844 bytes
+streamx: 46943 bytes
+```
+
+With optimizations turned on, the difference is even more stark:
+
+```
+$ for x in stream{,x}; do echo $x: $(browserify -r $x -p tinyify | wc -c) bytes; done
+stream: 62649 bytes
+streamx: 8460 bytes
+$ for x in stream{,x}; do echo $x: $(browserify -r $x -p tinyify | gzip | wc -c) "bytes (gzipped)"; done
+stream: 18053 bytes (gzipped)
+streamx: 2806 bytes (gzipped)
+```
+
 ## Usage
 
 ``` js


### PR DESCRIPTION
This patch adds browser payload size to the list of reasons to use this module instead of core streams.

```
$ for x in stream{,x}; do echo $x: $(browserify -r $x | wc -c) bytes; done
stream: 173844 bytes
streamx: 46943 bytes

$ for x in stream{,x}; do echo $x: $(browserify -r $x -p tinyify | wc -c) "bytes (optimized)"; done
stream: 62649 bytes (optimized)
streamx: 8460 bytes (optimized)

$ for x in stream{,x}; do echo $x: $(browserify -r $x -p tinyify | gzip | wc -c) "bytes optimized+gzipped)"; done
stream: 18053 bytes (optimized+gzipped)
streamx: 2806 bytes (optimized+gzipped)
```