### PR TITLE
Allowing options for Readable to be passed with Readable.from()

### DIFF
--- a/index.js
+++ b/index.js
@@ -633,10 +633,11 @@ class Readable extends Stream {
     this._duplexState &= READ_PAUSED
   }
 
-  static _fromAsyncIterator (ite) {
+  static _fromAsyncIterator (ite, opts) {
     let destroy
 
     const rs = new Readable({
+      ...opts,
       read (cb) {
         ite.next().then(push).then(cb.bind(null, null)).catch(cb)
       },
@@ -656,12 +657,13 @@ class Readable extends Stream {
     }
   }
 
-  static from (data) {
-    if (data[asyncIterator]) return this._fromAsyncIterator(data[asyncIterator]())
+  static from (data, opts = {}) {
+    if (data[asyncIterator]) return this._fromAsyncIterator(data[asyncIterator](), opts)
     if (!Array.isArray(data)) data = data === undefined ? [] : [data]
 
     let i = 0
     return new Readable({
+      ...opts,
       read (cb) {
         this.push(i === data.length ? null : data[i++])
         cb(null)

--- a/index.js
+++ b/index.js
@@ -657,7 +657,7 @@ class Readable extends Stream {
     }
   }
 
-  static from (data, opts = {}) {
+  static from (data, opts) {
     if (data[asyncIterator]) return this._fromAsyncIterator(data[asyncIterator](), opts)
     if (!Array.isArray(data)) data = data === undefined ? [] : [data]
 

--- a/test/readable.js
+++ b/test/readable.js
@@ -117,3 +117,19 @@ tape('from async iterator', function (t) {
     t.end()
   })
 })
+
+tape('from array with highWaterMark', function (t) {
+  const r = Readable.from([1, 2, 3], { highWaterMark: 1 })
+  t.same(r._readableState.highWaterMark, 1)
+  t.end()
+})
+
+tape('from async iterator with highWaterMark', function (t) {
+  async function * test () {
+    yield 1
+  }
+
+  const r = Readable.from(test(), { highWaterMark: 1 })
+  t.same(r._readableState.highWaterMark, 1)
+  t.end()
+})


### PR DESCRIPTION
When reading through the code I noticed that there are a few options that can be set for Readable's that are unreachable when using `Readable.from()`. This PR forwards options passed-in as second argument to the Readable.