### PR TITLE
Adding support for abort signals.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ stream: 18053 bytes (gzipped)
 streamx: 2806 bytes (gzipped)
 ```
 
+#### AbortSignal support
+
+To make it easier to integrate streams in a `async/await` flow, all streams support a `signal` option
+that accepts a [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) to as an
+alternative means to `.destroy` streams.
+
 ## Usage
 
 ``` js
@@ -103,7 +109,8 @@ Options include:
 {
   highWaterMark: 16384, // max buffer size in bytes
   map: (data) => data, // optional function to map input data
-  byteLength: (data) => size // optional function that calculates the byte size of input data
+  byteLength: (data) => size, // optional function that calculates the byte size of input data
+  signal: abortController.signal // optional AbortSignal that triggers `.destroy` when on `abort`
 }
 ```
 
@@ -251,7 +258,8 @@ Options include:
 {
   highWaterMark: 16384, // max buffer size in bytes
   map: (data) => data, // optional function to map input data
-  byteLength: (data) => size // optional function that calculates the byte size of input data
+  byteLength: (data) => size, // optional function that calculates the byte size of input data
+  signal: abortController.signal // optional AbortSignal that triggers `.destroy` when on `abort`
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -517,6 +517,9 @@ class Stream extends EventEmitter {
       if (opts.open) this._open = opts.open
       if (opts.destroy) this._destroy = opts.destroy
       if (opts.predestroy) this._predestroy = opts.predestroy
+      if (opts.signal) {
+        opts.signal.addEventListener('abort', abort.bind(this))
+      }
     }
   }
 
@@ -885,6 +888,10 @@ function defaultByteLength (data) {
 }
 
 function noop () {}
+
+function abort () {
+  this.destroy(new Error('Stream aborted.'))
+}
 
 module.exports = {
   isStream,

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "nanoassert": "^2.0.0"
   },
   "devDependencies": {
+    "abort-controller": "^3.0.0",
     "end-of-stream": "^1.4.1",
     "standard": "^14.3.1",
     "tape": "^4.11.0"


### PR DESCRIPTION
I am trying to make sure that the API's I use are all abortable. This Pull requests adds a `signal` option to readable streams that may trigger an Abort-Error during the reading of a stream.

Note: I am suspecting that this way of adding it is not in the way how it should be added and am very willing to update the PR after suggestions on how it could work differently.