### PR TITLE
Adding tests and support for any kind of TypedArray

### DIFF
--- a/index.js
+++ b/index.js
@@ -875,7 +875,7 @@ function isStreamx (stream) {
 }
 
 function isTypedArray (data) {
-  return typeof data === 'object' && typeof data.byteLength === 'number'
+  return typeof data === 'object' && data !== null && typeof data.byteLength === 'number'
 }
 
 function defaultByteLength (data) {

--- a/index.js
+++ b/index.js
@@ -875,7 +875,7 @@ function isStreamx (stream) {
 }
 
 function defaultByteLength (data) {
-  return Buffer.isBuffer(data) ? data.length : 1024
+  return typeof data === 'object' && typeof data.byteLength === 'number' ? data.byteLength : 1024
 }
 
 function noop () {}

--- a/index.js
+++ b/index.js
@@ -874,8 +874,12 @@ function isStreamx (stream) {
   return typeof stream._duplexState === 'number' && isStream(stream)
 }
 
+function isTypedArray (data) {
+  return typeof data === 'object' && typeof data.byteLength === 'number'
+}
+
 function defaultByteLength (data) {
-  return typeof data === 'object' && typeof data.byteLength === 'number' ? data.byteLength : 1024
+  return isTypedArray(data) ? data.byteLength : 1024
 }
 
 function noop () {}

--- a/test/byte-length.js
+++ b/test/byte-length.js
@@ -1,0 +1,44 @@
+const tape = require('tape')
+const { Readable, Writable } = require('../')
+
+const defaultSizes = [
+  { name: 'buf512', item: Buffer.alloc(512), size: 512 },
+  { name: 'number', item: 1, size: 1024 },
+  { name: 'number-byteLength', item: 1, size: 512, byteLength: () => 512 },
+  { name: 'number-byteLengthReadable', item: 1, size: 256, byteLength: () => 512, byteLengthExtended : () => 256 },
+  { name: 'uint8-512', item: new Uint8Array(512), size: 512 },
+  { name: 'uint32-64', item: new Uint32Array(64), size: 256 }
+]
+
+for (const { name, item, size, byteLength, byteLengthExtended } of defaultSizes) {
+  tape(`readable ${name}`, function (t) {
+    const r = new Readable({ byteLength, byteLengthReadable: byteLengthExtended })
+    r.push(item)
+    t.same(r._readableState.buffered, size)
+    t.end()
+  })
+  tape(`writable ${name}`, function (t) {
+    const w = new Writable({ byteLength, byteLengthWritable: byteLengthExtended })
+    w.write(item)
+    t.same(w._writableState.buffered, size)
+    t.end()
+  })
+}
+tape('byteLength receives readable item', function (t) {
+  const obj = {}
+  const r = new Readable({ byteLength: data => {
+    t.equals(obj, data)
+    t.end()
+  }})
+  r.push(obj)
+})
+tape('byteLength receives writable item', function (t) {
+  const obj = {}
+  const r = new Writable({ byteLength: data => {
+    t.equals(obj, data)
+    return 1
+  }})
+  r.write(obj)
+  t.end()
+})
+


### PR DESCRIPTION
I noticed that processing `Uint8Array` would not use the `.byteLength` but rather a static `1024` bytes for reaching the `highWaterMark`. This PR fixes this to support any kind of `TypedArray` (or any object property with `.bufferLength` really) to evaluate the `highWaterMark`. It also adds tests for the `.byteLength` property itself.