### PR TITLE
Readable.from(readable) to return the readable instead of a new stream

### DIFF
--- a/index.js
+++ b/index.js
@@ -663,6 +663,7 @@ class Readable extends Stream {
   }
 
   static from (data, opts) {
+    if (isReadStreamx(data)) return data
     if (data[asyncIterator]) return this._fromAsyncIterator(data[asyncIterator](), opts)
     if (!Array.isArray(data)) data = data === undefined ? [] : [data]
 
@@ -883,6 +884,10 @@ function isStream (stream) {
 
 function isStreamx (stream) {
   return typeof stream._duplexState === 'number' && isStream(stream)
+}
+
+function isReadStreamx (stream) {
+  return isStreamx(stream) && stream.readable
 }
 
 function isTypedArray (data) {

--- a/test/readable.js
+++ b/test/readable.js
@@ -171,3 +171,9 @@ tape('unshift', async function (t) {
   t.same(inc, [0, 1, 2])
   t.end()
 })
+
+tape('from readable should return the original readable', function (t) {
+  const r = new Readable()
+  t.equal(Readable.from(r), r)
+  t.end()
+})


### PR DESCRIPTION
This PR prevents creating a new Readable stream from a perfectly functional readable stream.