### PR TITLE
fixing unshift

### DIFF
--- a/index.js
+++ b/index.js
@@ -275,7 +275,7 @@ class ReadableState {
     let tail
     const pending = []
 
-    while ((tail === this.queue.shift()) !== undefined) {
+    while ((tail = this.queue.shift()) !== undefined) {
       pending.push(tail)
     }
 

--- a/test/readable.js
+++ b/test/readable.js
@@ -133,3 +133,17 @@ tape('from async iterator with highWaterMark', function (t) {
   t.same(r._readableState.highWaterMark, 1)
   t.end()
 })
+
+tape('unshift', async function (t) {
+  const r = new Readable()
+  r.push(1)
+  r.push(2)
+  r.unshift(0)
+  r.push(null)
+  const inc = []
+  for await (const entry of r) {
+    inc.push(entry)
+  }
+  t.same(inc, [0, 1, 2])
+  t.end()
+})


### PR DESCRIPTION
Using `Readable.unshift` caused an endless loop when there is an item in the queue. This PR adds a simple `unshift` test and fixes the issue.