### PR TITLE
adding isPaused method and tests for pause/resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ as to why this stream was destroyed.
 
 Pauses the stream. You will only need to call this if you want to pause a resumed stream.
 
+Returns this stream instance.
+
 #### `rs.resume()`
 
 Will start reading data from the stream as fast as possible.
@@ -201,6 +203,12 @@ If you do not call this, you need to use the `read()` method to read data or the
 pipe the stream somewhere else or the `data` handler.
 
 If none of these option are used the stream will stay paused.
+
+Returns this stream instance.
+
+#### `bool = Readable.isPaused(rs)`
+
+Returns `true` if the stream is paused, else `false`.
 
 #### `writableStream = rs.pipe(writableStream, [callback])`
 

--- a/index.js
+++ b/index.js
@@ -630,10 +630,12 @@ class Readable extends Stream {
   resume () {
     this._duplexState |= READ_RESUMED
     this._readableState.updateNextTick()
+    return this
   }
 
   pause () {
     this._duplexState &= READ_PAUSED
+    return this
   }
 
   static _fromAsyncIterator (ite, opts) {
@@ -676,6 +678,10 @@ class Readable extends Stream {
 
   static isBackpressured (rs) {
     return (rs._duplexState & READ_BACKPRESSURE_STATUS) !== 0 || rs._readableState.buffered >= rs._readableState.highWaterMark
+  }
+
+  static isPaused (rs) {
+    return (rs._duplexState & READ_RESUMED) === 0
   }
 
   [asyncIterator] () {

--- a/test/readable.js
+++ b/test/readable.js
@@ -21,6 +21,30 @@ tape('ondata', function (t) {
   })
 })
 
+function nextImmediate () {
+  return new Promise(resolve => setImmediate(resolve))
+}
+
+tape('pause', async function (t) {
+  const r = new Readable()
+  const buffered = []
+  t.equals(Readable.isPaused(r), true, 'starting off paused')
+  r.on('data', data => buffered.push(data))
+  r.on('close', () => t.end())
+  r.push('hello')
+  await nextImmediate()
+  t.equals(r.pause(), r, '.pause() returns self')
+  t.equals(Readable.isPaused(r), true, '.pause() marks stream as paused')
+  r.push('world')
+  await nextImmediate()
+  t.same(buffered, ['hello'], '.pause() prevents data to be read')
+  t.equals(r.resume(), r, '.resume() returns self')
+  t.equals(Readable.isPaused(r), false, '.resume() marks stream as resumed')
+  await nextImmediate()
+  t.same(buffered, ['hello', 'world'])
+  r.push(null)
+})
+
 tape('resume', function (t) {
   const r = new Readable()
   let ended = 0


### PR DESCRIPTION
This PR adds the [`.isPaused`](https://nodejs.org/api/stream.html#stream_readable_ispaused) method and lets `.resume` and `.pause` return the instance itself which should make it behave like the nodejs api.