### PR TITLE
Let ws.end return the writable

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,8 @@ Gracefully end the writable stream. Call this when you no longer want to write t
 
 Once all writes have been fully drained `finish` will be emitted.
 
+Returns this stream instance.
+
 #### `ws._final(callback)`
 
 This function is called just before `finish` is emitted, i.e. when all writes have flushed but `ws.end()`

--- a/index.js
+++ b/index.js
@@ -784,6 +784,7 @@ class Writable extends Stream {
   end (data) {
     this._writableState.updateNextTick()
     this._writableState.end(data)
+    return this
   }
 }
 
@@ -821,6 +822,7 @@ class Duplex extends Readable { // and Writable
   end (data) {
     this._writableState.updateNextTick()
     this._writableState.end(data)
+    return this
   }
 }
 

--- a/test/compat.js
+++ b/test/compat.js
@@ -81,7 +81,7 @@ function run (eos) {
     })
 
     w.write('hello')
-    w.end()
+    t.equals(w.end(), w)
     w.destroy()
   })
 
@@ -103,7 +103,7 @@ function run (eos) {
     s.push('hello')
     s.push(null)
     s.resume()
-    s.end()
+    t.equals(s.end(), s)
   })
 
   tape(name + ' duplex + deferred s.end()', function (t) {


### PR DESCRIPTION
This PR lets the `ws.end()` method return the writable instance, same as node.js [`.end()` method](https://nodejs.org/api/stream.html#stream_writable_end_chunk_encoding_callback) does.