### PR TITLE
use queueMicrotask instead of process.nextTick

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,7 +109,7 @@ class WritableState {
     this.byteLength = byteLengthWritable || byteLength || defaultByteLength
     this.map = mapWritable || map
     this.afterWrite = afterWrite.bind(this)
-    this._updateNT = updateWriteNT.bind(this)
+    this.afterUpdateNextTick = updateWriteNT.bind(this)
   }
 
   get ended () {
@@ -199,7 +199,7 @@ class WritableState {
   updateNextTick () {
     if ((this.stream._duplexState & WRITE_NEXT_TICK) !== 0) return
     this.stream._duplexState |= WRITE_NEXT_TICK
-    queueMicrotask(this._updateNT)
+    queueMicrotask(this.afterUpdateNextTick)
   }
 }
 
@@ -215,7 +215,7 @@ class ReadableState {
     this.map = mapReadable || map
     this.pipeTo = null
     this.afterRead = afterRead.bind(this)
-    this._updateNT = updateReadNT.bind(this)
+    this.afterUpdateNextTick = updateReadNT.bind(this)
   }
 
   get ended () {
@@ -359,7 +359,7 @@ class ReadableState {
   updateNextTick () {
     if ((this.stream._duplexState & READ_NEXT_TICK) !== 0) return
     this.stream._duplexState |= READ_NEXT_TICK
-    queueMicrotask(this._updateNT)
+    queueMicrotask(this.afterUpdateNextTick)
   }
 }
 


### PR DESCRIPTION
Replaced process.nextTick with queueMicrotask, since there was no direct reason to use nextTick, based my decision on https://nodejs.org/api/process.html#process_when_to_use_queuemicrotask_vs_process_nexttick

The problem is with `process`'s browserified version of `process.nextTick`. It uses a `setTimeout(fn, 0)` as a fallback, this is a major performance issue with large amounts of data and calls.