### PR TITLE
fix: change destroy byteflag for asyncIterator

### DIFF
--- a/index.js
+++ b/index.js
@@ -711,7 +711,7 @@ class Readable extends Stream {
           promiseReject = reject
           const data = stream.read()
           if (data !== null) ondata(data)
-          else if ((stream._duplexState & DESTROYED) !== 0) ondata(null)
+          else if ((stream._duplexState & DESTROY_STATUS) !== 0) ondata(null)
         })
       },
       return () {


### PR DESCRIPTION
https://github.com/streamxorg/streamx/issues/55
!!! This is a patch, not a fix. I could not find the underlying issue, but it seems like the stream never actually finishes destroying after it ends with asyncIterator, again could not find why, but this seemed like a very reliable way of checking if it should have ended without breaking anything.