### PR TITLE
Pipeline.afterPipe is applied only if function

### DIFF
--- a/index.js
+++ b/index.js
@@ -225,6 +225,7 @@ class ReadableState {
 
   pipe (pipeTo, cb) {
     if (this.pipeTo !== null) throw new Error('Can only pipe to one destination')
+    if (typeof cb !== 'function') cb = null
 
     this.stream._duplexState |= READ_PIPE_DRAINED
     this.pipeTo = pipeTo
@@ -410,7 +411,7 @@ class Pipeline {
       }
     }
 
-    if (this.afterPipe !== null && (typeof this.afterPipe === 'function')) this.afterPipe(this.error)
+    if (this.afterPipe !== null) this.afterPipe(this.error)
     this.to = this.from = this.afterPipe = null
   }
 }

--- a/index.js
+++ b/index.js
@@ -410,7 +410,7 @@ class Pipeline {
       }
     }
 
-    if (this.afterPipe !== null) this.afterPipe(this.error)
+    if (this.afterPipe !== null && (typeof this.afterPipe === 'function')) this.afterPipe(this.error)
     this.to = this.from = this.afterPipe = null
   }
 }


### PR DESCRIPTION
This fixes a bug when `afterPipe` is an object and Pipeline tries to apply