### PR TITLE
Duplex state is inconsistent when receiving data from node core Readable

### DIFF
--- a/test/compat.js
+++ b/test/compat.js
@@ -176,3 +176,22 @@ function run (eos) {
     s.destroy()
   })
 }
+
+tape('nodeStream: duplex writableState is ended when Readable has no more data', function (t) {
+  const { Readable } = require('stream')
+  t.plan(1)
+
+  const d = new stream.Duplex({
+    read (cb) {
+      t.equals(d._writableState.ended, true)
+      this.push(null)
+      cb()
+    },
+    write (data, cb) {
+      this.push(data)
+      cb()
+    }
+  })
+
+  Readable.from([]).pipe(d).pipe(new stream.Writable())
+})

--- a/test/duplex.js
+++ b/test/duplex.js
@@ -1,5 +1,5 @@
 const tape = require('tape')
-const { Duplex } = require('../')
+const { Duplex, Readable, Writable } = require('../')
 
 tape('if open does not end, it should stall', function (t) {
   t.plan(1)
@@ -41,4 +41,22 @@ tape('Using both mapReadable and mapWritable to map data', function (t) {
   })
   d.write('32')
   d.end()
+})
+
+tape('Ends the writableState when Readable has no more data', function (t) {
+  t.plan(1)
+
+  const d = new Duplex({
+    read (cb) {
+      t.equals(d._writableState.ended, true)
+      this.push(null)
+      cb()
+    },
+    write (data, cb) {
+      this.push(data)
+      cb()
+    }
+  })
+
+  Readable.from([]).pipe(d).pipe(new Writable())
 })


### PR DESCRIPTION
This PR introduces 2 tests:
1. Streamx's `Readable.from` is provided an empty array and the Duplex stream marks the writable side as ended
2. Node core `Readable.from` is provided an empty array but the Duplex stream does **not** mark the writable side as ended

I'm not sure why this inconsistency exists, but I'm trying to update [to-through](https://github.com/gulpjs/to-through) to use a Duplex stream instead of a Transform stream (to better handle backpressure) and this is the failing case in my test suite.